### PR TITLE
Composer Install時にHOMEを指定

### DIFF
--- a/provisioning/image/ansible/07_application.yml
+++ b/provisioning/image/ansible/07_application.yml
@@ -37,6 +37,8 @@
         - composer
 
     - name: Install Composer
+      environment:
+        HOME: /home/isucon
       shell: php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer
       when: "'Installer verified' in composer_setup_verify.stdout"
       tags:


### PR DESCRIPTION
Composer Install時にHOMEが設定されていなくてコケる問題の解消
https://github.com/catatsuy/private-isu/issues/552

